### PR TITLE
fix(layout): remove max-width constraint from html element

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -136,7 +136,6 @@
 	html {
 		height: 100%;
 		overflow-x: visible;
-		max-width: 100vw;
 		scroll-behavior: smooth;
 	}
 


### PR DESCRIPTION
- Remove max-width: 100vw from html element to restore normal width behavior